### PR TITLE
Fix switch for Win10 and it's test-value for future

### DIFF
--- a/DockerMsftProvider.psm1
+++ b/DockerMsftProvider.psm1
@@ -584,7 +584,7 @@ function InstallContainer
     }
     else
     {
-        switch -regex (get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption ){                
+        switch -regex (Get-CimInstance -ClassName Win32_OperatingSystem | select-object -ExpandProperty Caption ){
             'Microsoft Windows 10' {
                 $containerExists = Get-WindowsOptionalFeature -Online -FeatureName Containers | 
                 Select-object -Property *,@{name='Installed';expression={$_.State -eq 'Enabled'}}
@@ -599,7 +599,7 @@ function InstallContainer
         else
         {
             Write-Verbose "Installing Containers..."
-            switch -regex (get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption ){                
+            switch -regex (Get-CimInstance -ClassName Win32_OperatingSystem | select-object -ExpandProperty Caption ){
                 'Microsoft Windows 10' {$null = Enable-WindowsOptionalFeature -FeatureName Containers}
                 Default {$null = Install-WindowsFeature containers}
             }
@@ -618,7 +618,7 @@ function UninstallContainer
     }
     else
     {
-        switch -regex (get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption ){
+        switch -regex (Get-CimInstance -ClassName Win32_OperatingSystem | select-object -ExpandProperty Caption ){
             'Microsoft Windows 10' {$null = Disable-WindowsOptionalFeature -FeatureName Containers}
             Default {$null = Uninstall-WindowsFeature containers        }
         }

--- a/DockerMsftProvider.psm1
+++ b/DockerMsftProvider.psm1
@@ -584,7 +584,7 @@ function InstallContainer
     }
     else
     {
-        switch(Get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption ){                
+        switch -regex (get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption ){                
             'Microsoft Windows 10' {
                 $containerExists = Get-WindowsOptionalFeature -Online -FeatureName Containers | 
                 Select-object -Property *,@{name='Installed';expression={$_.State -eq 'Enabled'}}
@@ -599,7 +599,7 @@ function InstallContainer
         else
         {
             Write-Verbose "Installing Containers..."
-            switch(Get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption ){                
+            switch -regex (get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption ){                
                 'Microsoft Windows 10' {$null = Enable-WindowsOptionalFeature -FeatureName Containers}
                 Default {$null = Install-WindowsFeature containers}
             }
@@ -618,7 +618,7 @@ function UninstallContainer
     }
     else
     {
-        switch(Get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption ){
+        switch -regex (get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption ){
             'Microsoft Windows 10' {$null = Disable-WindowsOptionalFeature -FeatureName Containers}
             Default {$null = Uninstall-WindowsFeature containers        }
         }


### PR DESCRIPTION
https://github.com/OneGet/MicrosoftDockerProvider/commit/32db09b31b80e22c294b2602f3d688bdcbcfffac adds the regex switch to switch statement so it actually matches captions like "Microsoft Windows 10 Pro"
https://github.com/OneGet/MicrosoftDockerProvider/commit/b242ccb8dbe111c330334b2dab37e6bae3cabfd2 changes gwmi to Get-CimInstance as it appears it has been finally deprecated after years of warning, in PS6