### PR TITLE
Remove import-module for nonexistent SaveHTTPItemsUsingBITS.psm1

### DIFF
--- a/DockerMsftProvider.psm1
+++ b/DockerMsftProvider.psm1
@@ -1538,8 +1538,6 @@ function DownloadFile
         if($downloadURL.StartsWith("https://"))
         {
             Write-Verbose "Downloading $downloadUrl to $destination"
-            $saveItemPath = $PSScriptRoot + "\SaveHTTPItemUsingBITS.psm1"
-            Import-Module "$saveItemPath"
             $startTime = Get-Date
             Write-Verbose "About to download"
             Invoke-WebRequest -Uri $downloadURL `


### PR DESCRIPTION
BITS was replaced with Invoke-WebRequest but the module still attempts to load a nonexistent SaveHTTPItemUsingBITS module. This causes Install-Package to throw an exception.