### PR TITLE
Add channel support via RequiredVersion

### DIFF
--- a/DockerMsftProvider.psd1
+++ b/DockerMsftProvider.psd1
@@ -12,7 +12,7 @@
 RootModule = 'DockerMsftProvider.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0.3'
+ModuleVersion = '1.0.0.5'
 
 # ID used to uniquely identify this module
 GUID = '5beed3da-526b-47eb-9197-29c6a7214e4e'


### PR DESCRIPTION
Allow users to pass a channel name, such as '18.03', as the RequiredVersion parameter to Install-Package. The channel name is resolved to the latest version, based on the package source.

Signed-off-by: John Stephens <johnstep@docker.com>

```
PS C:\> Install-Package Docker -ProviderName DockerMsftProvider -RequiredVersion 18.03 -Force

Name                           Version          Source           Summary
----                           -------          ------           -------
Docker                         18.03.1-ee-1     DockerDefault    Contains Docker EE for use with Windows Server.
```

@taylorb-microsoft I bumped the version to 1.0.0.5 since the current release is 1.0.0.4, which I could not find in any of the branches here. However, the code otherwise matched this, the master branch.