### PR TITLE
fix: SHA256 check fail continue as if it had succeed

### DIFF
--- a/DockerMsftProvider.psm1
+++ b/DockerMsftProvider.psm1
@@ -1469,24 +1469,23 @@ function DownloadPackageHelper
 
     if((-not $hashCheck))
     {
+        Write-Error -Message "Cannot verify the file SHA256. Deleting the file."
         $null = remove-item -Path $fullDestinationPath -Force
-        Write-Error -Message "Cannot verify the file SHA256. Deleting the file."                
     }
+    else {
+        Write-Verbose "Hash verified!"
+        $savedWindowsPackageItem = Microsoft.PowerShell.Utility\New-Object PSCustomObject -Property ([ordered]@{
+            SourceName = $source
+            Name = $name
+            Version = $version
+            Description = $description 
+            Date = $date
+            URL = $originPath
+            Size = $size
+            sha256 = $sha })
 
-    Write-Verbose "Hash verified!"
-
-    $savedWindowsPackageItem = Microsoft.PowerShell.Utility\New-Object PSCustomObject -Property ([ordered]@{
-                        SourceName = $source
-                        Name = $name
-                        Version = $version
-                        Description = $description 
-                        Date = $date
-                        URL = $originPath
-                        Size = $size
-                        sha256 = $sha
-    })
-
-    Write-Output (New-SoftwareIdentityFromDockerInfo $savedWindowsPackageItem)
+        Write-Output (New-SoftwareIdentityFromDockerInfo $savedWindowsPackageItem)
+    }
 }
 
 function GenerateFullPath


### PR DESCRIPTION
Manual installation always fails when SHA 256 hash (verified manually and OK with same commandlet from the psm1) fail from the manifest https://dockermsft.blob.core.windows.net/dockercontainer/DockerMsftIndex.json :
![image](https://user-images.githubusercontent.com/10860719/42739709-ebd8b72e-88e7-11e8-9cbb-fdad402d6580.png)

On 16th July, manifest looks like it's broken to install Docker version 18 EE (version test, same version reference twice, etc) :
![image](https://user-images.githubusercontent.com/10860719/42739728-4b4b5536-88e8-11e8-8385-a2668a5f684c.png)
![image](https://user-images.githubusercontent.com/10860719/42739739-8912d3c6-88e8-11e8-8527-cb2bbd72a24c.png)

