### PR TITLE
Fix InstallContainer error when using DockerMSFTProvider on Windows 10

### DIFF
--- a/DockerMsftProvider.psd1
+++ b/DockerMsftProvider.psd1
@@ -12,7 +12,7 @@
 RootModule = 'DockerMsftProvider.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0.5'
+ModuleVersion = '1.0.0.6'
 
 # ID used to uniquely identify this module
 GUID = '5beed3da-526b-47eb-9197-29c6a7214e4e'

--- a/DockerMsftProvider.psm1
+++ b/DockerMsftProvider.psm1
@@ -584,8 +584,9 @@ function InstallContainer
     }
     else
     {
-        switch(Get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption ){                
-            'Microsoft Windows 10' {
+        [string] $OSCaption = Get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption
+        switch -WildCard ($OSCaption) {                
+            'Microsoft Windows 10*' {
                 $containerExists = Get-WindowsOptionalFeature -Online -FeatureName Containers | 
                 Select-object -Property *,@{name='Installed';expression={$_.State -eq 'Enabled'}}
             }
@@ -599,8 +600,8 @@ function InstallContainer
         else
         {
             Write-Verbose "Installing Containers..."
-            switch(Get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption ){                
-                'Microsoft Windows 10' {$null = Enable-WindowsOptionalFeature -FeatureName Containers}
+            switch -WildCard ($OSCaption) {                
+                'Microsoft Windows 10*' {$null = Enable-WindowsOptionalFeature -FeatureName Containers}
                 Default {$null = Install-WindowsFeature containers}
             }
             $script:restartRequired = $true            

--- a/DockerMsftProvider.psm1
+++ b/DockerMsftProvider.psm1
@@ -619,9 +619,10 @@ function UninstallContainer
     }
     else
     {
-        switch(Get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption ){
-            'Microsoft Windows 10' {$null = Disable-WindowsOptionalFeature -FeatureName Containers}
-            Default {$null = Uninstall-WindowsFeature containers        }
+        [string] $OSCaption = Get-wmiobject -class win32_operatingsystem | select-object -ExpandProperty Caption
+        switch -WildCard ($OSCaption) {
+            'Microsoft Windows 10*' {$null = Disable-WindowsOptionalFeature -FeatureName Containers}
+            Default {$null = Uninstall-WindowsFeature containers}
         }
         
     }


### PR DESCRIPTION
Fix [InstallContainer error](https://github.com/OneGet/MicrosoftDockerProvider/issues/47) when using DockerMSFTProvider to install Docker EE on Windows 10.