### PR TITLE
fix '$env:TEMP' path resolving issue

### DIFF
--- a/DockerMsftProvider.psm1
+++ b/DockerMsftProvider.psm1
@@ -13,7 +13,7 @@ Microsoft.PowerShell.Core\Set-StrictMode -Version Latest
 
 $script:Providername = "DockerMsftProvider"
 $script:DockerSources = $null
-$script:location_modules = Microsoft.PowerShell.Management\Join-Path -Path $env:TEMP -ChildPath $script:ProviderName
+$script:location_modules = Microsoft.PowerShell.Management\Join-Path -Path (Get-Item $env:TEMP).FullName -ChildPath $script:ProviderName
 $script:location_sources= Microsoft.PowerShell.Management\Join-Path -Path $env:LOCALAPPDATA -ChildPath $script:ProviderName
 $script:file_modules = Microsoft.PowerShell.Management\Join-Path -Path $script:location_sources -ChildPath "sources.txt"
 $script:DockerSearchIndex = "DockerSearchIndex.json"


### PR DESCRIPTION
`$env:TEMP` can be resolved to DOS-style path like 'C:\Users\ARZZ~1.BOK\AppData\Local\Temp', and then after `Join-Path` the resulting literal path is invalid.
If you `Test-Path $script:location_modules`, you get `false` in this case.
It causes that `remove-item` in line 334 fails the installation.