### PR TITLE
Fix to enable install on Windows 10

### DIFF
--- a/DockerMsftProvider.psm1
+++ b/DockerMsftProvider.psm1
@@ -316,15 +316,15 @@ function Install-Package
                 {
                     'hyperv'
                     {
-                        $null = New-Service -Name Docker -BinaryPathName "`"$script:pathDockerD`" --run-service --exec-opt isolation=hyperv"
+                        & "$script:pathDockerD" --exec-opt isolation=hyperv --register-service
                     }
                     'process'
                     {
-                        $null = New-Service -Name Docker -BinaryPathName "`"$script:pathDockerD`" --run-service --exec-opt isolation=process"
+                        & "$script:pathDockerD" --exec-opt isolation=process --register-service
                     }
                     default
                     {
-                        $null = New-Service -Name Docker -BinaryPathName "`"$script:pathDockerD`" --run-service"
+                        & "$script:pathDockerD" --register-service
                     }
                 }
 


### PR DESCRIPTION
Script doesn't support installation on latest Windows 10 versions because of an incorrect test. However, it can run the same code for both Windows 10 and Windows Server.
Windows Server supports both Install-WindowsFeature and Enable-WindowsOptionalFeature.
The difference is that Install-WindowsFeature can be used for both local and remote machine, whereas Enable-WindowsOptionalFeature is only for local machine.
We are not installing in a remote machine, so we safely use Enable-WindowsOptionalFeature, no matter if the install runs on Windows 10 or Windows Server.

Other changes:
- Add an option 'isolationMode' to set the default isolation mode
- Clean up of some unusual PowerShell notation
