### PR TITLE
Fix bugs with Updating and Removing Env Variables

### DIFF
--- a/DockerMsftProvider.psm1
+++ b/DockerMsftProvider.psm1
@@ -689,7 +689,7 @@ function Update-PathVar
     {
         if($currItem.Trim() -match [regex]::Escape($script:pathDockerRoot)) 
         {
-            $currFlag = $true
+            $currFlag = $false
             break
         }
     }
@@ -744,7 +744,7 @@ function Remove-PathVar
     }
     if($currFlag)
     {
-        $newPath = $envVars -replace [regex]::Escape($script:pathDockerRoot),$null
+        $newPath = $currPath -replace [regex]::Escape($script:pathDockerRoot),$null
         $newPath = $newPath -replace (";;"), ";"
         $null = Microsoft.PowerShell.Management\Set-ItemProperty $script:SystemEnvironmentKey -Name $NameOfPath -Value $newPath
     }


### PR DESCRIPTION
I have discovered two bugs with this module:

1. If you're installing Docker and the Docker path already exists in your system `PATH` variable, `Update-VarPath` will continue to add the Docker path to your system variable. The line 692 change corrects this behavior.

2. When uninstalling docker, `Remove-VarPath` mistakenly uses the `envVars` variable instead of `currPath`. This will merge your currently running process's `PATH` and into your system variables `PATH` which can cause issues, as seen in this issue:

https://github.com/puppetlabs/puppetlabs-docker/issues/457

I tested it as much as I could locally. Let me know if I need to do any additional work to have this merged in.

Thanks!