### PR TITLE
Fix for issue #56: dummyName does not exist error

### DIFF
--- a/DockerMsftProvider.psm1
+++ b/DockerMsftProvider.psm1
@@ -301,7 +301,11 @@ function Install-Package
 
         # Rename the docker folder to become Docker
         $dummyName = 'dummyName'
-        $null = Rename-Item -Path $script:pathDockerRoot -NewName $env:ProgramFiles\$dummyName
+        while (!(Test-Path $env:ProgramFiles\$dummyName)) 
+		{ 
+			Start-Sleep 1
+			$null = Rename-Item -Path $script:pathDockerRoot -NewName $env:ProgramFiles\$dummyName -ErrorAction Continue -Verbose
+		}
         $null = Rename-Item -Path $env:ProgramFiles\$dummyName -NewName $script:pathDockerRoot     
 
         if(Test-Path $script:pathDockerD)


### PR DESCRIPTION
There is a timing issue between unzip and rename of docker folder to dummyName where it appears the Expand-Archive command hasn't fully released all locks even though the command has completed.

This fix retries until rename is successful. 
Alternatively, the rename step could probably be removed completely.