### PR TITLE
Use HEAD HTTP request to avoid downloading file twice

### DIFF
--- a/DockerMsftProvider.psm1
+++ b/DockerMsftProvider.psm1
@@ -1178,7 +1178,10 @@ function Get-HttpResponse
     }
 
     $httpClient = New-Object System.Net.Http.HttpClient
-    $response = $httpclient.GetAsync($Uri)
+    $request = New-Object System.Net.Http.HttpRequestMessage
+    $request.Method = [System.Net.Http.HttpMethod]::Head
+    $request.RequestUri = $Uri
+    $response = $httpclient.SendAsync($request)
 
     return $response
 }


### PR DESCRIPTION
I've tested the DockerMsftProvider in a VM with a simulated slow network connection and could reproduce the problem that the ZIP file isn't downloaded.
Looking closer it turns out that retrieving the download size is the problem. This has downloaded the whole zip file and then we retrieved the size. 
This PR does a HEAD request to just retrieve the header and not the whole file.

<img width="1270" alt="install-package-docker-with-pr-fix" src="https://user-images.githubusercontent.com/207759/63650344-f2b50380-c749-11e9-98b9-ad9eabfdb3df.png">

With the simulated 4MBit connection the download takes about 6-8 minutes and `Invoke-WebRequest` does a good job.

Fixes #15 
Fixes MicrosoftDocs/Virtualization-Documentation#919

Credits: Thanks @InteXX for showing me https://github.com/OneGet/MicrosoftDockerProvider/issues/15#issuecomment-310871007 which helped me to find the root cause of the problem.
